### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ GumGum is the leading in-image and in-screen advertising platform, driving brand
 
 ## Features
 - [x] Swift & Objective-C compatible
-- [x] Cocoapods support
+- [x] CocoaPods support
 - [x] Native light box for optimal video ads
 - [x] In-image, In-screen, & Native ad support
 - [x] OpenRTB 2.3 spec support
@@ -20,8 +20,8 @@ GumGum is the leading in-image and in-screen advertising platform, driving brand
 - If you have a feature request, open an issue.
 
 ## Installation
-#### Cocoapods
-If you have never used [Cocoapods] before, you'll need to [install it first].
+#### CocoaPods
+If you have never used [CocoaPods] before, you'll need to [install it first].
 ```
 pod 'GumGumiOSSDK'
 ```
@@ -193,5 +193,5 @@ Jake Peterson ([@jakenberg])
 [Stack Overflow]:http://www.stackoverflow.com/questions/tagged/gumgum
 [@GumGum]:https://twitter.com/GumGum
 [@jakenberg]:https://github.com/Jakenberg
-[Cocoapods]:http://cocoapods.org/
+[CocoaPods]:http://cocoapods.org/
 [install it first]:http://guides.cocoapods.org/using/getting-started.html


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
